### PR TITLE
FormDropdown: default option set on initial render

### DIFF
--- a/src/components/form/components/FormDropdown/FormDropdown.stories.js
+++ b/src/components/form/components/FormDropdown/FormDropdown.stories.js
@@ -36,6 +36,34 @@ storiesOf("Form Components/FormDropdown", module)
 
     return <ComponentWrapper />;
   })
+  .add("with default option", () => {
+    const options = [
+      {
+        label: "default",
+        value: "some_default_value",
+        default: true,
+      },
+    ].concat(generateOptions(3));
+
+    function ComponentWrapper() {
+      const [selected, setSelected] = useState(null);
+
+      return (
+        <FormDropdown
+          options={options}
+          placeholder={text("placeholder", "select smth")}
+          value={selected}
+          onChange={setSelected}
+          width={number("width", 200)}
+          withSearch={boolean("with search", false)}
+          multiple={boolean("multiple", false)}
+          disabled={boolean("disabled", false)}
+        />
+      );
+    }
+
+    return <ComponentWrapper />;
+  })
   .add("multiple", () => {
     const options = generateOptions(3);
 
@@ -58,17 +86,22 @@ storiesOf("Form Components/FormDropdown", module)
 
     return <ComponentWrapper />;
   })
-  .add("multiple with default option", () => {
+  .add("multiple with default options", () => {
     const options = [
       {
-        label: "default",
-        value: "some_default_value",
+        label: "default1",
+        value: "some_default_value_1",
+        default: true,
+      },
+      {
+        label: "default2",
+        value: "some_default_value_2",
         default: true,
       },
     ].concat(generateOptions(3));
 
     function ComponentWrapper() {
-      const [selected, setSelected] = useState([options[0]]);
+      const [selected, setSelected] = useState([]);
 
       return (
         <FormDropdown

--- a/src/components/form/components/FormDropdown/__tests__/FormDropdown.js
+++ b/src/components/form/components/FormDropdown/__tests__/FormDropdown.js
@@ -175,6 +175,33 @@ describe("FormDropdown tests", () => {
     ).toHaveLength(options.length);
   });
 
+  test("FormDropdown should set default option on initial render, if value is not setted", () => {
+    const options = [defaultOption].concat(generateOptions(5));
+
+    const { getByTestId } = renderFormDropdown({
+      options,
+    });
+
+    expect(onChangeMock.mock.calls[0][0]).toEqual(defaultOption);
+    expect(getByTestId(`${componentName}-control`)).toHaveTextContent(
+      defaultOption.label
+    );
+  });
+
+  test("FormDropdown should not set default option on initial render, if value is not setted", () => {
+    const options = [defaultOption].concat(generateOptions(5));
+
+    const { getByTestId } = renderFormDropdown({
+      options,
+      value: options[1],
+    });
+
+    expect(onChangeMock.mock.calls).toHaveLength(0);
+    expect(getByTestId(`${componentName}-control`)).toHaveTextContent(
+      options[1].label
+    );
+  });
+
   describe("FormDropdown multiple", () => {
     test("FormDropdown multiple should correctly handle multiple values", () => {
       const { getByTestId } = renderFormDropdown({
@@ -324,6 +351,35 @@ describe("FormDropdown tests", () => {
       expect(onChangeMock.mock.calls[0][0]).toEqual([defaultOption]);
       expect(getByTestId(`${componentName}-control`)).toHaveTextContent(
         defaultOption.label
+      );
+    });
+
+    test("FormDropdown multiple should set default option on initial render, if value is not setted", () => {
+      const options = [defaultOption].concat(generateOptions(5));
+
+      const { getByTestId } = renderFormDropdown({
+        options,
+        multiple: true,
+      });
+
+      expect(onChangeMock.mock.calls[0][0]).toEqual([defaultOption]);
+      expect(getByTestId(`${componentName}-control`)).toHaveTextContent(
+        defaultOption.label
+      );
+    });
+
+    test("FormDropdown should not set default option on initial render, if value is not setted", () => {
+      const options = [defaultOption].concat(generateOptions(5));
+
+      const { getByTestId } = renderFormDropdown({
+        options,
+        multiple: true,
+        value: [options[1]],
+      });
+
+      expect(onChangeMock.mock.calls).toHaveLength(0);
+      expect(getByTestId(`${componentName}-control`)).toHaveTextContent(
+        options[1].label
       );
     });
   });

--- a/src/components/form/components/FormDropdown/index.jsx
+++ b/src/components/form/components/FormDropdown/index.jsx
@@ -59,6 +59,15 @@ function FormDropdown({
     }
   }, [value]);
 
+  useEffect(() => {
+    const defaultOptions = options.filter(isDefault);
+    const hasDefault = Boolean(defaultOptions.length);
+
+    if (hasDefault && (!value || (multiple && value.length === 0))) {
+      handleChange(null);
+    }
+  }, []);
+
   const inputRef = useRef(null);
   const [inputValue, setInputValue] = useState("");
   const prevInputValue = usePrevious(inputValue);


### PR DESCRIPTION
# Changelog

1. **FormDropdown**:
    - если не установлено `value` при инишал рендере и есть дефолтный опшен(ы), то вызывается `onChange` с дефолтным опшеном(опшенами)
    - обновлены тесты и стори;